### PR TITLE
Optimise checking done in ContributionChecker::Checker#user_has_fork_of_repo?

### DIFF
--- a/lib/contribution-checker/checker.rb
+++ b/lib/contribution-checker/checker.rb
@@ -190,6 +190,14 @@ module ContributionChecker
       # First, if there are no forks for the repository, return false.
       return false if @repo[:forks_count] == 0
 
+      # Then check whether it's worth getting the list of forks
+      if @repo[:forks_count] <= 100
+        repo_forks = @client.forks @repo[:full_name], :per_page => 100
+        repo_forks.each do |f|
+          return true if f[:owner][:login] == @user[:login]
+        end
+      end
+
       # Then try to directly find a repository with the same name as the
       # repository in which the commit exists.
       potential_fork_nwo = "#{@user[:login]}/#{@repo[:name]}"


### PR DESCRIPTION
Optimises the checking done in `ContributionChecker::Checker#user_has_fork_of_repo?`, to avoid expensive API calls where possible.
- First, if there are no forks, return `false`.
- Second, determine whether we can potentially figure out whether the user has a fork in a single API call: get all forks if there are less than or equal to 100 (the first page, where the page size is set to the maximum of 100).
- Third, try to find a user's repository with the same full name (nwo) as the repository in which the commit exists.
- Then continue on to getting all the user's forks, and checking the parent of each fork until we potentially find one.
