### PR TITLE
Cater for change in Octokit behaviour

### DIFF
--- a/lib/contribution-checker/checker.rb
+++ b/lib/contribution-checker/checker.rb
@@ -51,6 +51,8 @@ module ContributionChecker
       @nwo, @sha = parse_commit_url @commit_url
       begin
         @commit = @client.commit @nwo, @sha
+      rescue ArgumentError
+        raise ContributionChecker::InvalidCommitUrlError
       rescue Octokit::NotFound
         raise ContributionChecker::InvalidCommitUrlError
       rescue Octokit::Unauthorized

--- a/spec/contribution-checker/checker_spec.rb
+++ b/spec/contribution-checker/checker_spec.rb
@@ -31,6 +31,22 @@ describe ContributionChecker::Checker do
       end
     end
 
+    context "when a repository URL is provided which isn't a commit URL" do
+      let(:checker) { checker = ContributionChecker::Checker.new \
+        :access_token => "your token",
+        :commit_url   => "https://github.com/github/linguist/blahblah"
+      }
+
+      before do
+        stub_request(:get, "https://api.github.com/repos/github/linguist/commits/").to_return(
+        :status  => 404, :body => "")
+      end
+
+      it "raises an error" do
+        expect { checker.check }.to raise_error ContributionChecker::InvalidCommitUrlError
+      end
+    end
+
     context "when an invalid access token is provided" do
       let(:checker) { checker = ContributionChecker::Checker.new \
         :access_token => "invalid access token",


### PR DESCRIPTION
While working on a new branch, I noticed this test failing because of a change in Octokit's exception handling behaviour:

https://travis-ci.org/jdennes/contribution-checker/builds/51730061#L135

This fixes that.