### PR TITLE
Check whether a commit was authored using a generic email

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,12 @@ checker.check
 => {
   :contribution => true,
   :and_criteria => {
+    :commit_email_is_not_generic => true,
     :commit_in_valid_branch      => true,
     :commit_in_last_year         => true,
     :repo_not_a_fork             => true,
     :commit_email_linked_to_user => true,
-    :commit_email                => "example@example.com",
+    :commit_email                => "me@foo.com",
     :default_branch              => "master"
   },
   :or_criteria => {

--- a/lib/contribution-checker/checker.rb
+++ b/lib/contribution-checker/checker.rb
@@ -269,6 +269,7 @@ module ContributionChecker
     #
     # @return [Boolean]
     def and_criteria_met?
+      @commit_email_is_not_generic &&
       @commit_in_valid_branch &&
       @commit_in_last_year &&
       @repo_not_a_fork &&

--- a/spec/contribution-checker/checker_spec.rb
+++ b/spec/contribution-checker/checker_spec.rb
@@ -137,6 +137,7 @@ describe ContributionChecker::Checker do
 
         expect(result[:contribution]).to eq(true)
 
+        expect(result[:and_criteria][:commit_email_is_not_generic]).to eq(true)
         expect(result[:and_criteria][:commit_in_valid_branch]).to eq(true)
         expect(result[:and_criteria][:commit_in_last_year]).to eq(true)
         expect(result[:and_criteria][:repo_not_a_fork]).to eq(true)
@@ -183,6 +184,7 @@ describe ContributionChecker::Checker do
 
         expect(result[:contribution]).to eq(true)
 
+        expect(result[:and_criteria][:commit_email_is_not_generic]).to eq(true)
         expect(result[:and_criteria][:commit_in_valid_branch]).to eq(true)
         expect(result[:and_criteria][:commit_in_last_year]).to eq(true)
         expect(result[:and_criteria][:repo_not_a_fork]).to eq(true)
@@ -229,6 +231,7 @@ describe ContributionChecker::Checker do
 
         expect(result[:contribution]).to eq(true)
 
+        expect(result[:and_criteria][:commit_email_is_not_generic]).to eq(true)
         expect(result[:and_criteria][:commit_in_valid_branch]).to eq(true)
         expect(result[:and_criteria][:commit_in_last_year]).to eq(true)
         expect(result[:and_criteria][:repo_not_a_fork]).to eq(true)
@@ -275,6 +278,7 @@ describe ContributionChecker::Checker do
 
         expect(result[:contribution]).to eq(false)
 
+        expect(result[:and_criteria][:commit_email_is_not_generic]).to eq(true)
         expect(result[:and_criteria][:commit_in_valid_branch]).to eq(false)
         expect(result[:and_criteria][:commit_in_last_year]).to eq(true)
         expect(result[:and_criteria][:repo_not_a_fork]).to eq(true)
@@ -322,6 +326,7 @@ describe ContributionChecker::Checker do
 
         expect(result[:contribution]).to eq(true)
 
+        expect(result[:and_criteria][:commit_email_is_not_generic]).to eq(true)
         expect(result[:and_criteria][:commit_in_valid_branch]).to eq(true)
         expect(result[:and_criteria][:commit_in_last_year]).to eq(true)
         expect(result[:and_criteria][:repo_not_a_fork]).to eq(true)
@@ -368,6 +373,7 @@ describe ContributionChecker::Checker do
 
         expect(result[:contribution]).to eq(true)
 
+        expect(result[:and_criteria][:commit_email_is_not_generic]).to eq(true)
         expect(result[:and_criteria][:commit_in_valid_branch]).to eq(true)
         expect(result[:and_criteria][:commit_in_last_year]).to eq(true)
         expect(result[:and_criteria][:repo_not_a_fork]).to eq(true)
@@ -414,6 +420,7 @@ describe ContributionChecker::Checker do
 
         expect(result[:contribution]).to eq(true)
 
+        expect(result[:and_criteria][:commit_email_is_not_generic]).to eq(true)
         expect(result[:and_criteria][:commit_in_valid_branch]).to eq(true)
         expect(result[:and_criteria][:commit_in_last_year]).to eq(true)
         expect(result[:and_criteria][:repo_not_a_fork]).to eq(true)
@@ -464,6 +471,7 @@ describe ContributionChecker::Checker do
 
         expect(result[:contribution]).to eq(true)
 
+        expect(result[:and_criteria][:commit_email_is_not_generic]).to eq(true)
         expect(result[:and_criteria][:commit_in_valid_branch]).to eq(true)
         expect(result[:and_criteria][:commit_in_last_year]).to eq(true)
         expect(result[:and_criteria][:repo_not_a_fork]).to eq(true)
@@ -514,6 +522,7 @@ describe ContributionChecker::Checker do
 
         expect(result[:contribution]).to eq(true)
 
+        expect(result[:and_criteria][:commit_email_is_not_generic]).to eq(true)
         expect(result[:and_criteria][:commit_in_valid_branch]).to eq(true)
         expect(result[:and_criteria][:commit_in_last_year]).to eq(true)
         expect(result[:and_criteria][:repo_not_a_fork]).to eq(true)

--- a/spec/contribution-checker/checker_spec.rb
+++ b/spec/contribution-checker/checker_spec.rb
@@ -63,6 +63,51 @@ describe ContributionChecker::Checker do
       end
     end
 
+    context "when a commit is authored using a generic email address" do
+      let(:checker) { checker = ContributionChecker::Checker.new \
+        :access_token => "token",
+        :commit_url   => "https://github.com/jdennes/contribution-checker/commit/731e83d4abf1bd67ac6ab68d18387693482e47cf"
+      }
+
+      before do
+        stub_get("/repos/jdennes/contribution-checker/commits/731e83d4abf1bd67ac6ab68d18387693482e47cf").
+          to_return(json_response("commit_with_generic_email.json"))
+        stub_get("/repos/jdennes/contribution-checker").
+          to_return(json_response("repo.json"))
+        stub_get("/user").
+          to_return(json_response("user.json"))
+        stub_get("/repos/jdennes/contribution-checker/compare/master...731e83d4abf1bd67ac6ab68d18387693482e47cf").
+          to_return(json_response("default_compare.json"))
+        stub_get("/user/emails").
+          to_return(json_response("emails.json"))
+        stub_get("/user/starred/jdennes/contribution-checker").
+          to_return(:status => 404)
+        stub_get("/repos/jdennes/contribution-checker/issues?creator=jdennes&state=all").
+          to_return(json_response("issues_and_prs.json"))
+        end
+
+      it "returns the check result" do
+        result = checker.check
+        expect(result).to be_a(Hash)
+
+        expect(result[:contribution]).to eq(false)
+
+        expect(result[:and_criteria][:commit_email_is_not_generic]).to eq(false)
+        expect(result[:and_criteria][:commit_in_valid_branch]).to eq(true)
+        expect(result[:and_criteria][:commit_in_last_year]).to eq(true)
+        expect(result[:and_criteria][:repo_not_a_fork]).to eq(true)
+        expect(result[:and_criteria][:commit_email_linked_to_user]).to eq(true)
+        expect(result[:and_criteria][:commit_email]).to eq("another@example.com")
+        expect(result[:and_criteria][:default_branch]).to eq("master")
+
+        expect(result[:or_criteria][:user_has_starred_repo]).to eq(false)
+        expect(result[:or_criteria][:user_can_push_to_repo]).to eq(true)
+        expect(result[:or_criteria][:user_is_repo_org_member]).to eq(false)
+        expect(result[:or_criteria][:user_has_fork_of_repo]).to eq(false)
+        expect(result[:or_criteria][:user_has_opened_issue_or_pr_in_repo]).to eq(true)
+      end
+    end
+
     context "when a commit is in the default branch and is successfully checked" do
       let(:checker) { checker = ContributionChecker::Checker.new \
         :access_token => "token",

--- a/spec/contribution-checker/checker_spec.rb
+++ b/spec/contribution-checker/checker_spec.rb
@@ -96,7 +96,7 @@ describe ContributionChecker::Checker do
         expect(result[:and_criteria][:commit_in_last_year]).to eq(true)
         expect(result[:and_criteria][:repo_not_a_fork]).to eq(true)
         expect(result[:and_criteria][:commit_email_linked_to_user]).to eq(true)
-        expect(result[:and_criteria][:commit_email]).to eq("example@example.com")
+        expect(result[:and_criteria][:commit_email]).to eq("me@foo.com")
         expect(result[:and_criteria][:default_branch]).to eq("master")
 
         expect(result[:or_criteria][:user_has_starred_repo]).to eq(false)
@@ -142,7 +142,7 @@ describe ContributionChecker::Checker do
         expect(result[:and_criteria][:commit_in_last_year]).to eq(true)
         expect(result[:and_criteria][:repo_not_a_fork]).to eq(true)
         expect(result[:and_criteria][:commit_email_linked_to_user]).to eq(true)
-        expect(result[:and_criteria][:commit_email]).to eq("example@example.com")
+        expect(result[:and_criteria][:commit_email]).to eq("me@foo.com")
         expect(result[:and_criteria][:default_branch]).to eq("master")
 
         expect(result[:or_criteria][:user_has_starred_repo]).to eq(false)
@@ -188,7 +188,7 @@ describe ContributionChecker::Checker do
         expect(result[:and_criteria][:commit_in_last_year]).to eq(true)
         expect(result[:and_criteria][:repo_not_a_fork]).to eq(true)
         expect(result[:and_criteria][:commit_email_linked_to_user]).to eq(true)
-        expect(result[:and_criteria][:commit_email]).to eq("example@example.com")
+        expect(result[:and_criteria][:commit_email]).to eq("me@foo.com")
         expect(result[:and_criteria][:default_branch]).to eq("master")
 
         expect(result[:or_criteria][:user_has_starred_repo]).to eq(false)
@@ -234,7 +234,7 @@ describe ContributionChecker::Checker do
         expect(result[:and_criteria][:commit_in_last_year]).to eq(true)
         expect(result[:and_criteria][:repo_not_a_fork]).to eq(true)
         expect(result[:and_criteria][:commit_email_linked_to_user]).to eq(true)
-        expect(result[:and_criteria][:commit_email]).to eq("example@example.com")
+        expect(result[:and_criteria][:commit_email]).to eq("me@foo.com")
         expect(result[:and_criteria][:default_branch]).to eq("master")
 
         expect(result[:or_criteria][:user_has_starred_repo]).to eq(false)
@@ -281,7 +281,7 @@ describe ContributionChecker::Checker do
         expect(result[:and_criteria][:commit_in_last_year]).to eq(true)
         expect(result[:and_criteria][:repo_not_a_fork]).to eq(true)
         expect(result[:and_criteria][:commit_email_linked_to_user]).to eq(true)
-        expect(result[:and_criteria][:commit_email]).to eq("example@example.com")
+        expect(result[:and_criteria][:commit_email]).to eq("me@foo.com")
         expect(result[:and_criteria][:default_branch]).to eq("master")
 
         expect(result[:or_criteria][:user_has_starred_repo]).to eq(false)
@@ -327,7 +327,7 @@ describe ContributionChecker::Checker do
         expect(result[:and_criteria][:commit_in_last_year]).to eq(true)
         expect(result[:and_criteria][:repo_not_a_fork]).to eq(true)
         expect(result[:and_criteria][:commit_email_linked_to_user]).to eq(true)
-        expect(result[:and_criteria][:commit_email]).to eq("example@example.com")
+        expect(result[:and_criteria][:commit_email]).to eq("me@foo.com")
         expect(result[:and_criteria][:default_branch]).to eq("master")
 
         expect(result[:or_criteria][:user_has_starred_repo]).to eq(false)
@@ -373,7 +373,7 @@ describe ContributionChecker::Checker do
         expect(result[:and_criteria][:commit_in_last_year]).to eq(true)
         expect(result[:and_criteria][:repo_not_a_fork]).to eq(true)
         expect(result[:and_criteria][:commit_email_linked_to_user]).to eq(true)
-        expect(result[:and_criteria][:commit_email]).to eq("example@example.com")
+        expect(result[:and_criteria][:commit_email]).to eq("me@foo.com")
         expect(result[:and_criteria][:default_branch]).to eq("master")
 
         expect(result[:or_criteria][:user_has_starred_repo]).to eq(false)
@@ -423,7 +423,7 @@ describe ContributionChecker::Checker do
         expect(result[:and_criteria][:commit_in_last_year]).to eq(true)
         expect(result[:and_criteria][:repo_not_a_fork]).to eq(true)
         expect(result[:and_criteria][:commit_email_linked_to_user]).to eq(true)
-        expect(result[:and_criteria][:commit_email]).to eq("example@example.com")
+        expect(result[:and_criteria][:commit_email]).to eq("me@foo.com")
         expect(result[:and_criteria][:default_branch]).to eq("master")
 
         expect(result[:or_criteria][:user_has_starred_repo]).to eq(false)
@@ -473,7 +473,7 @@ describe ContributionChecker::Checker do
         expect(result[:and_criteria][:commit_in_last_year]).to eq(true)
         expect(result[:and_criteria][:repo_not_a_fork]).to eq(true)
         expect(result[:and_criteria][:commit_email_linked_to_user]).to eq(true)
-        expect(result[:and_criteria][:commit_email]).to eq("example@example.com")
+        expect(result[:and_criteria][:commit_email]).to eq("me@foo.com")
         expect(result[:and_criteria][:default_branch]).to eq("master")
 
         expect(result[:or_criteria][:user_has_starred_repo]).to eq(false)

--- a/spec/fixtures/commit.json
+++ b/spec/fixtures/commit.json
@@ -3,12 +3,12 @@
   "commit": {
     "author": {
       "name": "James Dennes",
-      "email": "example@example.com",
+      "email": "me@foo.com",
       "date": "2014-06-08T10:25:34Z"
     },
     "committer": {
       "name": "James Dennes",
-      "email": "example@example.com",
+      "email": "me@foo.com",
       "date": "2014-06-08T10:25:34Z"
     },
     "message": "Version 0.0.2",

--- a/spec/fixtures/commit_with_generic_email.json
+++ b/spec/fixtures/commit_with_generic_email.json
@@ -1,0 +1,89 @@
+{
+  "sha": "731e83d4abf1bd67ac6ab68d18387693482e47cf",
+  "commit": {
+    "author": {
+      "name": "James Dennes",
+      "email": "another@example.com",
+      "date": "2014-06-08T10:25:34Z"
+    },
+    "committer": {
+      "name": "James Dennes",
+      "email": "another@example.com",
+      "date": "2014-06-08T10:25:34Z"
+    },
+    "message": "Version 0.0.2",
+    "tree": {
+      "sha": "30d937ac96b77183e8df7f319acc1e4387516981",
+      "url": "https://api.github.com/repos/jdennes/contribution-checker/git/trees/30d937ac96b77183e8df7f319acc1e4387516981"
+    },
+    "url": "https://api.github.com/repos/jdennes/contribution-checker/git/commits/731e83d4abf1bd67ac6ab68d18387693482e47cf",
+    "comment_count": 0
+  },
+  "url": "https://api.github.com/repos/jdennes/contribution-checker/commits/731e83d4abf1bd67ac6ab68d18387693482e47cf",
+  "html_url": "https://github.com/jdennes/contribution-checker/commit/731e83d4abf1bd67ac6ab68d18387693482e47cf",
+  "comments_url": "https://api.github.com/repos/jdennes/contribution-checker/commits/731e83d4abf1bd67ac6ab68d18387693482e47cf/comments",
+  "author": {
+    "login": "jdennes",
+    "id": 65057,
+    "avatar_url": "https://avatars.githubusercontent.com/u/65057?",
+    "gravatar_id": "55fd031da91ef9af6e6ed88b101416a1",
+    "url": "https://api.github.com/users/jdennes",
+    "html_url": "https://github.com/jdennes",
+    "followers_url": "https://api.github.com/users/jdennes/followers",
+    "following_url": "https://api.github.com/users/jdennes/following{/other_user}",
+    "gists_url": "https://api.github.com/users/jdennes/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/jdennes/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/jdennes/subscriptions",
+    "organizations_url": "https://api.github.com/users/jdennes/orgs",
+    "repos_url": "https://api.github.com/users/jdennes/repos",
+    "events_url": "https://api.github.com/users/jdennes/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/jdennes/received_events",
+    "type": "User",
+    "site_admin": true
+  },
+  "committer": {
+    "login": "jdennes",
+    "id": 65057,
+    "avatar_url": "https://avatars.githubusercontent.com/u/65057?",
+    "gravatar_id": "55fd031da91ef9af6e6ed88b101416a1",
+    "url": "https://api.github.com/users/jdennes",
+    "html_url": "https://github.com/jdennes",
+    "followers_url": "https://api.github.com/users/jdennes/followers",
+    "following_url": "https://api.github.com/users/jdennes/following{/other_user}",
+    "gists_url": "https://api.github.com/users/jdennes/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/jdennes/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/jdennes/subscriptions",
+    "organizations_url": "https://api.github.com/users/jdennes/orgs",
+    "repos_url": "https://api.github.com/users/jdennes/repos",
+    "events_url": "https://api.github.com/users/jdennes/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/jdennes/received_events",
+    "type": "User",
+    "site_admin": true
+  },
+  "parents": [
+    {
+      "sha": "5514532ab61216d1d7d242fd624a2f215d225a31",
+      "url": "https://api.github.com/repos/jdennes/contribution-checker/commits/5514532ab61216d1d7d242fd624a2f215d225a31",
+      "html_url": "https://github.com/jdennes/contribution-checker/commit/5514532ab61216d1d7d242fd624a2f215d225a31"
+    }
+  ],
+  "stats": {
+    "total": 2,
+    "additions": 1,
+    "deletions": 1
+  },
+  "files": [
+    {
+      "sha": "d8853e79dea5d3235cb470f4ea1de0ec2d17bcb5",
+      "filename": "lib/contribution-checker/version.rb",
+      "status": "modified",
+      "additions": 1,
+      "deletions": 1,
+      "changes": 2,
+      "blob_url": "https://github.com/jdennes/contribution-checker/blob/731e83d4abf1bd67ac6ab68d18387693482e47cf/lib/contribution-checker/version.rb",
+      "raw_url": "https://github.com/jdennes/contribution-checker/raw/731e83d4abf1bd67ac6ab68d18387693482e47cf/lib/contribution-checker/version.rb",
+      "contents_url": "https://api.github.com/repos/jdennes/contribution-checker/contents/lib/contribution-checker/version.rb?ref=731e83d4abf1bd67ac6ab68d18387693482e47cf",
+      "patch": "@@ -1,3 +1,3 @@\n module ContributionChecker\n-  VERSION = \"0.0.1\"\n+  VERSION = \"0.0.2\"\n end"
+    }
+  ]
+}

--- a/spec/fixtures/default_compare.json
+++ b/spec/fixtures/default_compare.json
@@ -9,12 +9,12 @@
     "commit": {
       "author": {
         "name": "James Dennes",
-        "email": "example@example.com",
+        "email": "me@foo.com",
         "date": "2014-06-08T22:47:15Z"
       },
       "committer": {
         "name": "James Dennes",
-        "email": "example@example.com",
+        "email": "me@foo.com",
         "date": "2014-06-08T22:47:15Z"
       },
       "message": "Add ContributionChecker::InvalidAccessTokenError",
@@ -79,12 +79,12 @@
     "commit": {
       "author": {
         "name": "James Dennes",
-        "email": "example@example.com",
+        "email": "me@foo.com",
         "date": "2014-06-08T10:25:34Z"
       },
       "committer": {
         "name": "James Dennes",
-        "email": "example@example.com",
+        "email": "me@foo.com",
         "date": "2014-06-08T10:25:34Z"
       },
       "message": "Version 0.0.2",

--- a/spec/fixtures/default_compare_ahead.json
+++ b/spec/fixtures/default_compare_ahead.json
@@ -9,12 +9,12 @@
     "commit": {
       "author": {
         "name": "James Dennes",
-        "email": "example@example.com",
+        "email": "me@foo.com",
         "date": "2014-06-08T22:47:15Z"
       },
       "committer": {
         "name": "James Dennes",
-        "email": "example@example.com",
+        "email": "me@foo.com",
         "date": "2014-06-08T22:47:15Z"
       },
       "message": "Add ContributionChecker::InvalidAccessTokenError",
@@ -79,12 +79,12 @@
     "commit": {
       "author": {
         "name": "James Dennes",
-        "email": "example@example.com",
+        "email": "me@foo.com",
         "date": "2014-06-08T10:25:34Z"
       },
       "committer": {
         "name": "James Dennes",
-        "email": "example@example.com",
+        "email": "me@foo.com",
         "date": "2014-06-08T10:25:34Z"
       },
       "message": "Version 0.0.2",

--- a/spec/fixtures/emails.json
+++ b/spec/fixtures/emails.json
@@ -1,6 +1,6 @@
 [
   {
-    "email": "example@example.com",
+    "email": "me@foo.com",
     "primary": false,
     "verified": true
   },

--- a/spec/fixtures/gh-pages_compare.json
+++ b/spec/fixtures/gh-pages_compare.json
@@ -9,12 +9,12 @@
     "commit": {
       "author": {
         "name": "James Dennes",
-        "email": "example@example.com",
+        "email": "me@foo.com",
         "date": "2014-06-08T22:47:15Z"
       },
       "committer": {
         "name": "James Dennes",
-        "email": "example@example.com",
+        "email": "me@foo.com",
         "date": "2014-06-08T22:47:15Z"
       },
       "message": "Add ContributionChecker::InvalidAccessTokenError",
@@ -79,12 +79,12 @@
     "commit": {
       "author": {
         "name": "James Dennes",
-        "email": "example@example.com",
+        "email": "me@foo.com",
         "date": "2014-06-08T10:25:34Z"
       },
       "committer": {
         "name": "James Dennes",
-        "email": "example@example.com",
+        "email": "me@foo.com",
         "date": "2014-06-08T10:25:34Z"
       },
       "message": "Version 0.0.2",


### PR DESCRIPTION
Fixes #13 by adding [this method](https://github.com/jdennes/contribution-checker/blob/3bb69e115c3367cd19d67675ffafadc755625152/lib/contribution-checker/checker.rb#L114-L124):

```ruby
# Checks that the commit was not authored using a non-generic email.
# For example, this will return false when the commit was authored using
# emails like me@example.com, me@localhost, me@fake.org, etc.
#
# @return [Boolean]
def commit_email_is_not_generic?
  @commit[:commit][:author][:email] !~ Regexp.union(
    /[@.](example|test|fake|none)\.?(com|net|org)?\z/i,
    /[@.]local\.?(host)?\z/i,
  )
end
```

The updated check result hash now includes `[:and_criteria][:commit_email_is_not_generic]`:

https://github.com/jdennes/contribution-checker/blob/3bb69e115c3367cd19d67675ffafadc755625152/lib/contribution-checker/checker.rb#L80

/cc @izuzak 