### PR TITLE
Remove "within last year" requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ checker.check
   :and_criteria => {
     :commit_email_is_not_generic => true,
     :commit_in_valid_branch      => true,
-    :commit_in_last_year         => true,
     :repo_not_a_fork             => true,
     :commit_email_linked_to_user => true,
     :commit_email                => "me@foo.com",

--- a/lib/contribution-checker/checker.rb
+++ b/lib/contribution-checker/checker.rb
@@ -35,7 +35,6 @@ module ContributionChecker
     #   :and_criteria => {
     #     :commit_email_is_not_generic => true,
     #     :commit_in_valid_branch      => true,
-    #     :commit_in_last_year         => true,
     #     :repo_not_a_fork             => true,
     #     :commit_email_linked_to_user => true,
     #     :commit_email                => "me@foo.com",
@@ -65,7 +64,6 @@ module ContributionChecker
 
       @commit_email_is_not_generic = commit_email_is_not_generic?
       @commit_in_valid_branch = commit_in_valid_branch?
-      @commit_in_last_year = commit_in_last_year?
       @repo_not_a_fork = !repository_is_fork?
       @commit_email_linked_to_user = commit_email_linked_to_user?
       @user_has_starred_repo = user_has_starred_repo?
@@ -79,7 +77,6 @@ module ContributionChecker
         :and_criteria => {
           :commit_email_is_not_generic => @commit_email_is_not_generic,
           :commit_in_valid_branch      => @commit_in_valid_branch,
-          :commit_in_last_year         => @commit_in_last_year,
           :repo_not_a_fork             => @repo_not_a_fork,
           :commit_email_linked_to_user => @commit_email_linked_to_user,
           :commit_email                => @commit[:commit][:author][:email],
@@ -154,15 +151,6 @@ module ContributionChecker
       end
 
       true
-    end
-
-    # Checks whether the commit was authored in the last year.
-    #
-    # @return [Boolean]
-    def commit_in_last_year?
-      a_year_ago = Time.now - (365.25 * 86400)
-      commit_time = @commit[:commit][:author][:date]
-      (commit_time <=> a_year_ago) == 1
     end
 
     # Checks whether the repository is a fork.
@@ -271,7 +259,6 @@ module ContributionChecker
     def and_criteria_met?
       @commit_email_is_not_generic &&
       @commit_in_valid_branch &&
-      @commit_in_last_year &&
       @repo_not_a_fork &&
       @commit_email_linked_to_user
     end

--- a/spec/contribution-checker/checker_spec.rb
+++ b/spec/contribution-checker/checker_spec.rb
@@ -94,7 +94,6 @@ describe ContributionChecker::Checker do
 
         expect(result[:and_criteria][:commit_email_is_not_generic]).to eq(false)
         expect(result[:and_criteria][:commit_in_valid_branch]).to eq(true)
-        expect(result[:and_criteria][:commit_in_last_year]).to eq(true)
         expect(result[:and_criteria][:repo_not_a_fork]).to eq(true)
         expect(result[:and_criteria][:commit_email_linked_to_user]).to eq(true)
         expect(result[:and_criteria][:commit_email]).to eq("another@example.com")
@@ -139,7 +138,6 @@ describe ContributionChecker::Checker do
 
         expect(result[:and_criteria][:commit_email_is_not_generic]).to eq(true)
         expect(result[:and_criteria][:commit_in_valid_branch]).to eq(true)
-        expect(result[:and_criteria][:commit_in_last_year]).to eq(true)
         expect(result[:and_criteria][:repo_not_a_fork]).to eq(true)
         expect(result[:and_criteria][:commit_email_linked_to_user]).to eq(true)
         expect(result[:and_criteria][:commit_email]).to eq("me@foo.com")
@@ -186,7 +184,6 @@ describe ContributionChecker::Checker do
 
         expect(result[:and_criteria][:commit_email_is_not_generic]).to eq(true)
         expect(result[:and_criteria][:commit_in_valid_branch]).to eq(true)
-        expect(result[:and_criteria][:commit_in_last_year]).to eq(true)
         expect(result[:and_criteria][:repo_not_a_fork]).to eq(true)
         expect(result[:and_criteria][:commit_email_linked_to_user]).to eq(true)
         expect(result[:and_criteria][:commit_email]).to eq("me@foo.com")
@@ -233,7 +230,6 @@ describe ContributionChecker::Checker do
 
         expect(result[:and_criteria][:commit_email_is_not_generic]).to eq(true)
         expect(result[:and_criteria][:commit_in_valid_branch]).to eq(true)
-        expect(result[:and_criteria][:commit_in_last_year]).to eq(true)
         expect(result[:and_criteria][:repo_not_a_fork]).to eq(true)
         expect(result[:and_criteria][:commit_email_linked_to_user]).to eq(true)
         expect(result[:and_criteria][:commit_email]).to eq("me@foo.com")
@@ -280,7 +276,6 @@ describe ContributionChecker::Checker do
 
         expect(result[:and_criteria][:commit_email_is_not_generic]).to eq(true)
         expect(result[:and_criteria][:commit_in_valid_branch]).to eq(false)
-        expect(result[:and_criteria][:commit_in_last_year]).to eq(true)
         expect(result[:and_criteria][:repo_not_a_fork]).to eq(true)
         expect(result[:and_criteria][:commit_email_linked_to_user]).to eq(true)
         expect(result[:and_criteria][:commit_email]).to eq("me@foo.com")
@@ -328,7 +323,6 @@ describe ContributionChecker::Checker do
 
         expect(result[:and_criteria][:commit_email_is_not_generic]).to eq(true)
         expect(result[:and_criteria][:commit_in_valid_branch]).to eq(true)
-        expect(result[:and_criteria][:commit_in_last_year]).to eq(true)
         expect(result[:and_criteria][:repo_not_a_fork]).to eq(true)
         expect(result[:and_criteria][:commit_email_linked_to_user]).to eq(true)
         expect(result[:and_criteria][:commit_email]).to eq("me@foo.com")
@@ -375,7 +369,6 @@ describe ContributionChecker::Checker do
 
         expect(result[:and_criteria][:commit_email_is_not_generic]).to eq(true)
         expect(result[:and_criteria][:commit_in_valid_branch]).to eq(true)
-        expect(result[:and_criteria][:commit_in_last_year]).to eq(true)
         expect(result[:and_criteria][:repo_not_a_fork]).to eq(true)
         expect(result[:and_criteria][:commit_email_linked_to_user]).to eq(true)
         expect(result[:and_criteria][:commit_email]).to eq("me@foo.com")
@@ -422,7 +415,6 @@ describe ContributionChecker::Checker do
 
         expect(result[:and_criteria][:commit_email_is_not_generic]).to eq(true)
         expect(result[:and_criteria][:commit_in_valid_branch]).to eq(true)
-        expect(result[:and_criteria][:commit_in_last_year]).to eq(true)
         expect(result[:and_criteria][:repo_not_a_fork]).to eq(true)
         expect(result[:and_criteria][:commit_email_linked_to_user]).to eq(true)
         expect(result[:and_criteria][:commit_email]).to eq("me@foo.com")
@@ -473,7 +465,6 @@ describe ContributionChecker::Checker do
 
         expect(result[:and_criteria][:commit_email_is_not_generic]).to eq(true)
         expect(result[:and_criteria][:commit_in_valid_branch]).to eq(true)
-        expect(result[:and_criteria][:commit_in_last_year]).to eq(true)
         expect(result[:and_criteria][:repo_not_a_fork]).to eq(true)
         expect(result[:and_criteria][:commit_email_linked_to_user]).to eq(true)
         expect(result[:and_criteria][:commit_email]).to eq("me@foo.com")
@@ -524,7 +515,6 @@ describe ContributionChecker::Checker do
 
         expect(result[:and_criteria][:commit_email_is_not_generic]).to eq(true)
         expect(result[:and_criteria][:commit_in_valid_branch]).to eq(true)
-        expect(result[:and_criteria][:commit_in_last_year]).to eq(true)
         expect(result[:and_criteria][:repo_not_a_fork]).to eq(true)
         expect(result[:and_criteria][:commit_email_linked_to_user]).to eq(true)
         expect(result[:and_criteria][:commit_email]).to eq("me@foo.com")


### PR DESCRIPTION
With the new GitHub profile timeline, the contribution graph is not limited to the last year. Users can view contributions from years past.

Once this is merged, I can open a PR to make these changes in the contributions app and point it to the new version of the gem.

/cc @jdennes for review